### PR TITLE
Include maps directory in rsync

### DIFF
--- a/_live_server/git/rsync-include.inc
+++ b/_live_server/git/rsync-include.inc
@@ -6,6 +6,9 @@
 + .git/logs/
 + .git/logs/HEAD
 
++ maps/
++ maps/**
+
 + nano/
 + nano/**
 


### PR DESCRIPTION
(Disclaimer: I ~have never run this, and~ learned about rsync about four minutes ago.)

Apparently our infrastructure doesn't copy dmm files into the game directory, so the game can't access them for runtime maploading. So away sites are busted.

Let's fix that!